### PR TITLE
fix: ocaml support in neovim and abook

### DIFF
--- a/nixos/modules/programs/neovim/plugins/lua/extra-ls-clients.lua
+++ b/nixos/modules/programs/neovim/plugins/lua/extra-ls-clients.lua
@@ -7,3 +7,8 @@ lsp.r_language_server.setup({
     on_attach = __lspOnAttach,
     capabilities = __lspCapabilities()
 })
+
+lsp.ocamllsp.setup({
+    on_attach = __lspOnAttach,
+    capabilities = __lspCapabilities()
+})

--- a/nixos/modules/services/email.nix
+++ b/nixos/modules/services/email.nix
@@ -76,6 +76,7 @@
       };
 
       programs = {
+        abook.enable = true;
         aerc = {
           enable = true;
 
@@ -235,6 +236,10 @@
               "text/html" = "${pkgs.w3m}/bin/w3m -T text/html";
               "application/pdf" = "${hmcfg.programs.sioyek.package}/sioyek";
               "image/*" = "${pkgs.feh}/bin/feh";
+            };
+
+            compose = {
+              "address-book-cmd" = "${pkgs.abook}/bin/abook --mutt-query \"%s\"";
             };
           };
 


### PR DESCRIPTION
- Add OCaml LSP support
- Forgot to add the abook command
